### PR TITLE
Update PascalTriangle.cs

### DIFF
--- a/C#/PascalTriangle.cs
+++ b/C#/PascalTriangle.cs
@@ -9,7 +9,7 @@
 /// </summary>
 internal class PascalTriangle
 {
-    private static void PascalTriangle(int rowCount = 5)
+    private static void DisplayTriangle(int rowCount = 5)
     {
         for (int row = 1; row <= rowCount; row++)
         {


### PR DESCRIPTION
Renamed Method to avoid interfering with Class name which may result to error.

I just discovered that the method name`(PascalTriangle)` is the same as the class name`(PascalTriangle)`, which may result to an error. This `PR` contains the updated method name.